### PR TITLE
Crash on thread destruction

### DIFF
--- a/senjo/Platform.h
+++ b/senjo/Platform.h
@@ -25,6 +25,8 @@
 
 #ifdef WIN32
 #include <Windows.h>
+#undef max
+#undef min
 #endif
 
 #include <string>

--- a/senjo/UCIAdapter.cpp
+++ b/senjo/UCIAdapter.cpp
@@ -57,6 +57,13 @@ UCIAdapter::UCIAdapter(ChessEngine& chessEngine)
   : engine(chessEngine) {}
 
 //-----------------------------------------------------------------------------
+UCIAdapter::~UCIAdapter() {
+  if (lastCommand) {
+    lastCommand->waitForFinish();
+  }
+}
+
+//-----------------------------------------------------------------------------
 bool UCIAdapter::doCommand(const std::string& line) {
   Parameters params(line);
   if (params.empty()) {

--- a/senjo/UCIAdapter.h
+++ b/senjo/UCIAdapter.h
@@ -35,6 +35,7 @@ namespace senjo {
 class UCIAdapter {
 public:
   UCIAdapter(ChessEngine& engine);
+  ~UCIAdapter();
 
   //--------------------------------------------------------------------------
   //! \brief Execute the given one-line command


### PR DESCRIPTION
First off, thank you for this project, it's made engine development much easier and I've used my engine successfully with several GUIs.

I ran into this crash while debugging, it might be an unusual use case but I thought I'd send my fix over in case it's useful for anyone else. It doesn't happen every time, so likely timing related. This fix has been working for me though there could certainly be a better approach.

I have a file with UCI commands, and I send each line from the file to the engine via `UCIAdapter::doCommand` in `main` before exiting `main`. I think what is happening is that the `UCIAdapter` destructor is called before the `Thread::staticRun` is called. The `UCIAdapter`'s `backgroundCommand` will wait for the thread to finish, but `staticRun` ends up calling the virtual `doWork` method while the destructor is in progress. 

In general calling virtual functions from a destructor can lead to UB; I couldn't find any info on if it was safe to call virtual functions from a different thread while a destructor was in progress, but my guess is that is what is causing the crash. 

I also included a fix for compiling on Windows (MSVC 2022). Feel free to accept both or either (or neither).


Here is a screenshot of the crash in XCode (thread 2, line 67):
<img width="1406" alt="Screen Shot 2022-04-13 at 10 37 52 PM" src="https://user-images.githubusercontent.com/5062098/163474353-1b13959a-9e58-42e7-9380-eb89e9491a2f.png">
